### PR TITLE
Configurable Winopts

### DIFF
--- a/lua/showkeys/init.lua
+++ b/lua/showkeys/init.lua
@@ -19,7 +19,7 @@ M.open = function()
   state.timer = vim.loop.new_timer()
   state.on_key = vim.on_key(function(_, char)
     if not state.win then
-      state.win = api.nvim_open_win(state.buf, false, state.winopts)
+      state.win = api.nvim_open_win(state.buf, false, state.config.winopts)
       vim.wo[state.win].winhl = "FloatBorder:Comment,Normalfloat:Normal"
     end
 

--- a/lua/showkeys/state.lua
+++ b/lua/showkeys/state.lua
@@ -3,17 +3,18 @@ local M = {
   w = 1,
   extmark_id = nil,
 
-  winopts = {
-    focusable = false,
-    relative = "editor",
-    style = "minimal",
-    border = "single",
-    height = 1,
-    row = 1,
-    col = 0,
-  },
-
   config = {
+
+    winopts = {
+      focusable = false,
+      relative = "editor",
+      style = "minimal",
+      border = "single",
+      height = 1,
+      row = 1,
+      col = 0,
+    },
+
     timeout = 3, -- in secs
     maxkeys = 3,
     show_count = false,

--- a/lua/showkeys/utils.lua
+++ b/lua/showkeys/utils.lua
@@ -29,20 +29,20 @@ end
 M.gen_winconfig = function()
   local lines = vim.o.lines
   local cols = vim.o.columns
-  state.winopts.width = state.w
+  state.config.winopts.width = state.w
 
   local pos = state.config.position
 
   if string.find(pos, "bottom") then
-    state.winopts.row = lines - 5
+    state.config.winopts.row = lines - 5
   end
 
   if pos == "top-right" then
-    state.winopts.col = cols - state.w - 3
+    state.config.winopts.col = cols - state.w - 3
   elseif pos == "top-center" or pos == "bottom-center" then
-    state.winopts.col = math.floor(cols / 2) - math.floor(state.w / 2)
+    state.config.winopts.col = math.floor(cols / 2) - math.floor(state.w / 2)
   elseif pos == "bottom-right" then
-    state.winopts.col = cols - state.w - 3
+    state.config.winopts.col = cols - state.w - 3
   end
 end
 
@@ -55,7 +55,7 @@ local update_win_w = function()
   end
 
   M.gen_winconfig()
-  api.nvim_win_set_config(state.win, state.winopts)
+  api.nvim_win_set_config(state.win, state.config.winopts)
 end
 
 M.draw = function()


### PR DESCRIPTION
I wanted to change the border style, 
so I modified the position of winopts.
 
The structure may differ from what you had in mind, 
so I would appreciate it if you could review it.


> state.lua

```lua
-- as-is

local M = {
  keys = {},
  w = 1,
  extmark_id = nil,

  winopts = {
    focusable = false,
    relative = "editor",
    style = "minimal",
    border = "single",
    height = 1,
    row = 1,
    col = 0,
  },

  config = {
    timeout = 3,
    maxkeys = 3,
    show_count = false,
    excluded_modes = {}, 

    keyformat = {
      ["<BS>"] = "󰁮 ",
      ["<CR>"] = "󰘌",
      ["<Space>"] = "󱁐",
      ["<Up>"] = "󰁝",
      ["<Down>"] = "󰁅",
      ["<Left>"] = "󰁍",
      ["<Right>"] = "󰁔",
      ["<PageUp>"] = "Page 󰁝",
      ["<PageDown>"] = "Page 󰁅",
      ["<M>"] = "Alt",
      ["<C>"] = "Ctrl",
    },
  },
}

return M

-- to-be

local M = {
  keys = {},
  w = 1,
  extmark_id = nil,

  config = {
    winopts = { -- move hear
      focusable = false,
      relative = "editor",
      style = "minimal",
      border = "single",
      height = 1,
      row = 1,
      col = 0,
    },
    timeout = 3,
    maxkeys = 3,
    show_count = false,
    excluded_modes = {}, 

    keyformat = {
      ["<BS>"] = "󰁮 ",
      ["<CR>"] = "󰘌",
      ["<Space>"] = "󱁐",
      ["<Up>"] = "󰁝",
      ["<Down>"] = "󰁅",
      ["<Left>"] = "󰁍",
      ["<Right>"] = "󰁔",
      ["<PageUp>"] = "Page 󰁝",
      ["<PageDown>"] = "Page 󰁅",
      ["<M>"] = "Alt",
      ["<C>"] = "Ctrl",
    },
  },
}

return M


```