### PR TITLE
Maintain ShowKeys window when changing tabpage

### DIFF
--- a/lua/showkeys/init.lua
+++ b/lua/showkeys/init.lua
@@ -44,6 +44,16 @@ M.open = function()
   local augroup = api.nvim_create_augroup("ShowkeysAu", { clear = true })
   api.nvim_create_autocmd("VimResized", { group = augroup, callback = utils.redraw })
 
+	api.nvim_create_autocmd("TabEnter", {
+		group = augroup,
+		callback = function()
+			if state.win then
+				M.close()
+				M.open()
+			end
+		end,
+	})
+
   api.nvim_create_autocmd("WinClosed", {
     group = augroup,
     callback = function()

--- a/lua/showkeys/init.lua
+++ b/lua/showkeys/init.lua
@@ -44,15 +44,15 @@ M.open = function()
   local augroup = api.nvim_create_augroup("ShowkeysAu", { clear = true })
   api.nvim_create_autocmd("VimResized", { group = augroup, callback = utils.redraw })
 
-	api.nvim_create_autocmd("TabEnter", {
-		group = augroup,
-		callback = function()
-			if state.win then
-				M.close()
-				M.open()
-			end
-		end,
-	})
+  api.nvim_create_autocmd("TabEnter", {
+    group = augroup,
+    callback = function()
+      if state.win then
+        M.close()
+        M.open()
+      end
+    end,
+  })
 
   api.nvim_create_autocmd("WinClosed", {
     group = augroup,


### PR DESCRIPTION
Currently ShowKeys stop working the moment you switch tabpages. This admittedly crude commit fixes that by simply restarting the plugin on every TabEnter.