### PR TITLE
fix: orgname typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Check the [config table here](https://github.com/NvChad/showkeys/blob/main/lua/s
 
 ```lua
 {
-  "siduck/showkeys",
+  "nvzone/showkeys",
   cmd = "ShowkeysToggle",
   opts = {
     timeout = 1,


### PR DESCRIPTION
Fixed inconsistent fork name used in config example