### PR TITLE
feat: export visible

### DIFF
--- a/lua/showkeys/init.lua
+++ b/lua/showkeys/init.lua
@@ -90,4 +90,8 @@ M.toggle = function()
   M[state.visible and "close" or "open"]()
 end
 
+M.visible = function()
+  return state.visible
+end
+
 return M


### PR DESCRIPTION
Changed to output the current visible state.
This is useful for display in the UI.

<img width="1800" alt="スクリーンショット 2024-12-12 23 07 24" src="https://github.com/user-attachments/assets/a1b52792-2b78-4d0f-99dc-31d4a650c987" />

In this screener, it is a keymap of k.